### PR TITLE
Remove launcher functionality

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -58,11 +58,11 @@
             android:enabled="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <action android:name="android.intent.action.SHOW_WORK_APPS" />
+                <!-- <action android:name="android.intent.action.SHOW_WORK_APPS" /> -->
                 <category android:name="android.intent.category.HOME" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.MONKEY"/>
-                <category android:name="android.intent.category.LAUNCHER_APP" />
+                <!-- <category android:name="android.intent.category.DEFAULT" /> -->
+                <!-- <category android:name="android.intent.category.MONKEY"/> -->
+                <!-- <category android:name="android.intent.category.LAUNCHER_APP" /> -->
             </intent-filter>
             <meta-data
                 android:name="com.android.launcher3.grid.control"

--- a/quickstep/AndroidManifest-launcher.xml
+++ b/quickstep/AndroidManifest-launcher.xml
@@ -56,11 +56,11 @@
             android:enabled="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <action android:name="android.intent.action.SHOW_WORK_APPS" />
+                <!-- <action android:name="android.intent.action.SHOW_WORK_APPS" /> -->
                 <category android:name="android.intent.category.HOME" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.MONKEY"/>
-                <category android:name="android.intent.category.LAUNCHER_APP" />
+                <!-- <category android:name="android.intent.category.DEFAULT" /> -->
+                <!-- <category android:name="android.intent.category.MONKEY"/> -->
+                <!-- <category android:name="android.intent.category.LAUNCHER_APP" /> -->
             </intent-filter>
             <meta-data
                 android:name="com.android.launcher3.grid.control"


### PR DESCRIPTION
Seamlessly removed the launcher functionality from Launcher3. 

Note: Do not commit entire intent-filter, the App crashes.